### PR TITLE
[FE] FEATURE: Context API 설정

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+REACT_APP_OAUTH_URL="https://api.intra.42.fr/oauth/authorize?client_id=0e372797fd91fef15a10e97fd2a952579e778da6d4676992696fdba15cb61ea1&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&response_type=code"

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,0 @@
-REACT_APP_OAUTH_URL="https://api.intra.42.fr/oauth/authorize?client_id=0e372797fd91fef15a10e97fd2a952579e778da6d4676992696fdba15cb61ea1&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&response_type=code"

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.env
 
 npm-debug.log*
 yarn-debug.log*

--- a/frontend/db.json
+++ b/frontend/db.json
@@ -18,7 +18,7 @@
   },
   "user": {
     "id": 1,
-    "nickname": "",
+    "nickname": "dd",
     "email": "noenna@naver.com",
     "profileImg": "",
     "secondAuth": false

--- a/frontend/db.json
+++ b/frontend/db.json
@@ -15,5 +15,12 @@
   ],
   "profile": {
     "name": "typicode"
+  },
+  "user": {
+    "id": 1,
+    "nickname": "",
+    "email": "noenna@naver.com",
+    "profileImg": "",
+    "secondAuth": false
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,22 +10,25 @@ import NicknamPage from './pages/NicknamPage';
 import SecondAuthPage from './pages/SecondAuthPage';
 import GamePage from './pages/GamePage';
 import ChatPage from './pages/ChatPage';
+import { AllContextApi } from './store';
 
 function App() {
   return (
-    <ThemeProvider theme={theme}>
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<MainPage />} />
-          <Route path="/callback" element={<OauthPage />} />
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/nickname" element={<NicknamPage />} />
-          <Route path="/secondAuth" element={<SecondAuthPage />} />
-          <Route path="/game" element={<GamePage />} />
-          <Route path="/chat" element={<ChatPage />} />
-        </Routes>
-      </BrowserRouter>
-    </ThemeProvider>
+    <AllContextApi>
+      <ThemeProvider theme={theme}>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<MainPage />} />
+            <Route path="/callback" element={<OauthPage />} />
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/nickname" element={<NicknamPage />} />
+            <Route path="/secondAuth" element={<SecondAuthPage />} />
+            <Route path="/game" element={<GamePage />} />
+            <Route path="/chat" element={<ChatPage />} />
+          </Routes>
+        </BrowserRouter>
+      </ThemeProvider>
+    </AllContextApi>
   );
 }
 

--- a/frontend/src/components/common/Button.tsx
+++ b/frontend/src/components/common/Button.tsx
@@ -32,7 +32,7 @@ interface ButtonContainerProps {
 
 const ButtonContainer = styled.button<ButtonContainerProps>`
   ${({ color, gradient, theme }) =>
-    gradient ? `background: ${theme.colors[color]}` : `background-color: ${theme.colors[color]};`}
+    gradient ? `background: ${theme.colors[color]};` : `background-color: ${theme.colors[color]};`}
   width: ${({ width }) => width}px;
   height: ${({ height }) => height}px;
   color: ${({ color }) => (color === 'white' ? 'black' : 'white')};

--- a/frontend/src/components/common/Button.tsx
+++ b/frontend/src/components/common/Button.tsx
@@ -32,11 +32,11 @@ interface ButtonContainerProps {
 
 const ButtonContainer = styled.button<ButtonContainerProps>`
   ${({ color, gradient, theme }) =>
-    gradient ? `background: ${theme.colors[color]}` : `background-color: ${theme.colors[color]}`}
+    gradient ? `background: ${theme.colors[color]}` : `background-color: ${theme.colors[color]};`}
   width: ${({ width }) => width}px;
   height: ${({ height }) => height}px;
   color: ${({ color }) => (color === 'white' ? 'black' : 'white')};
-  border: ${({ color, theme }) => (color === 'white' ? `${theme.colors.main}` : 'none')};
+  border: ${({ color, theme }) => (color === 'white' ? `1px solid ${theme.colors.main}` : 'none')};
   border-radius: 10px;
   cursor: pointer;
   margin: 0 auto;

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -19,6 +19,15 @@ const LoginPage: React.FC = () => {
             console.log('click');
           }}
         />
+        <Button
+          width={200}
+          height={50}
+          color="white"
+          text="42 Login"
+          onClick={() => {
+            console.log('click');
+          }}
+        />
       </LoginBox>
     </LoginContainer>
   );

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -13,18 +13,13 @@ const LoginPage: React.FC = () => {
         <Button
           width={200}
           height={50}
-          color="gradient"
-          text="42 Login"
-          onClick={() => {
-            console.log('click');
-          }}
-        />
-        <Button
-          width={200}
-          height={50}
           color="white"
           text="42 Login"
           onClick={() => {
+            console.log(process.env.REACT_APP_OAUTH_URL);
+            if (process.env.REACT_APP_OAUTH_URL) {
+              location.href = process.env.REACT_APP_OAUTH_URL;
+            }
             console.log('click');
           }}
         />
@@ -44,10 +39,14 @@ const LoginBox = styled.div`
   width: 500px;
   height: 500px;
   background-color: white;
-  margin: 150px auto;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   border-radius: 20px;
   box-shadow: 6px 6px 10px 5px rgba(0, 0, 0, 0.1);
   padding: 20px;
+  box-sizing: border-box;
 `;
 const LogoWrap = styled.div`
   width: 90%;

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react';
 import { AllContext } from '../store';
-import { LOGIN, LOGOUT, SET_NICKNAME, SECOND_AUTH } from '../utils/interface';
 import GamePage from './GamePage';
 import LoginPage from './LoginPage';
 import NicknamPage from './NicknamPage';

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -1,11 +1,24 @@
-import React from 'react';
+import React, { useContext } from 'react';
+import { AllContext } from '../store';
+import { LOGIN, LOGOUT, SET_NICKNAME, SECOND_AUTH } from '../utils/interface';
+import GamePage from './GamePage';
+import LoginPage from './LoginPage';
+import NicknamPage from './NicknamPage';
 
 const MainPage: React.FC = () => {
+  const { userStatus } = useContext(AllContext).userStatus;
+
   return (
-    <div>
-      main page
-      {/* oauth ? 3mainpage : 0loginpage : 1nickname : 2secondauth */}
-    </div>
+    <>
+      {
+        {
+          LOGOUT: <LoginPage />,
+          SET_NICKNAME: <NicknamPage />,
+          SECOND_AUTH: <GamePage />,
+          LOGIN: <GamePage />,
+        }[userStatus]
+      }
+    </>
   );
 };
 

--- a/frontend/src/pages/OauthPage.tsx
+++ b/frontend/src/pages/OauthPage.tsx
@@ -2,7 +2,6 @@ import axios from 'axios';
 import React, { useEffect, useContext } from 'react';
 import { AllContext } from '../store';
 import { LOGIN, LOGOUT, SET_NICKNAME, SECOND_AUTH } from '../utils/interface';
-import MainPage from './MainPage';
 import { useNavigate } from 'react-router-dom';
 
 const OauthPage: React.FC = () => {

--- a/frontend/src/pages/OauthPage.tsx
+++ b/frontend/src/pages/OauthPage.tsx
@@ -1,7 +1,41 @@
-import React from 'react';
+import axios from 'axios';
+import React, { useEffect, useContext } from 'react';
+import { AllContext } from '../store';
+import { LOGIN, LOGOUT, SET_NICKNAME, SECOND_AUTH } from '../utils/interface';
+import MainPage from './MainPage';
+import { useNavigate } from 'react-router-dom';
 
 const OauthPage: React.FC = () => {
-  return <div>oauth page</div>;
+  const { userStatus, setUserStatus } = useContext(AllContext).userStatus;
+  const { setUser } = useContext(AllContext).userData;
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    // test 용 api
+    if (userStatus !== LOGOUT) {
+      return navigate('/');
+    }
+    const getUser = async () => {
+      const { data } = await axios('http://localhost:4000/user');
+      setUser('login', {
+        id: data.id,
+        nickname: data.nickname,
+        email: data.email,
+        profileImg: data.profileImg,
+        secondAuth: data.secondAuth,
+      });
+      if (!data.nickname) {
+        setUserStatus(SET_NICKNAME);
+      } else if (data.secondAuth) {
+        setUserStatus(SECOND_AUTH);
+      } else {
+        setUserStatus(LOGIN);
+      }
+    };
+    getUser();
+  }, [userStatus]);
+
+  return <></>;
 };
 
 export default OauthPage;

--- a/frontend/src/store/index.tsx
+++ b/frontend/src/store/index.tsx
@@ -1,0 +1,77 @@
+import React, { createContext, useState } from 'react';
+import { LOGIN, LOGOUT, SECOND_AUTH, SET_NICKNAME, User, UserStateType } from '../utils/interface';
+
+export const AllContext = createContext<stateType | null>(null);
+
+type stateType = {
+  modalData: {
+    state: boolean;
+    setState: () => void;
+  };
+  userData: {
+    state: User | null;
+    setState: (type: string, user?: User) => void;
+  };
+  userState: {
+    state: UserStateType;
+    setState: (type: UserStateType) => void;
+  };
+};
+
+interface AllContextApiProps {
+  children: React.ReactNode;
+}
+
+const AllContextApi = ({ children }: AllContextApiProps) => {
+  const [isModal, setIsModal] = useState<boolean>(false);
+  const [user, setUser] = useState<User | null>(null);
+  const [userState, setUserState] = useState<UserStateType>(LOGOUT);
+
+  const handleModal = () => {
+    setIsModal(!isModal);
+  };
+
+  const handleUser = (type: string, user?: User) => {
+    switch (type) {
+      case 'login':
+        if (user) {
+          setUser(user);
+          if (!user.nickname) {
+            setUserState(SET_NICKNAME);
+          } else if (user.secondAuth) {
+            setUserState(SECOND_AUTH);
+          } else {
+            setUserState(LOGIN);
+          }
+        }
+        return;
+      case 'logout':
+        setUser(null);
+        return;
+      default:
+        return;
+    }
+  };
+
+  const handleUserState = (type: UserStateType) => {
+    setUserState(type);
+  };
+
+  const data = {
+    modalData: {
+      state: isModal,
+      setState: handleModal,
+    },
+    userData: {
+      state: user,
+      setState: handleUser,
+    },
+    userState: {
+      state: userState,
+      setState: handleUserState,
+    },
+  };
+  return <AllContext.Provider value={data}>{children}</AllContext.Provider>;
+};
+
+export { AllContextApi };

--- a/frontend/src/store/index.tsx
+++ b/frontend/src/store/index.tsx
@@ -1,20 +1,33 @@
 import React, { createContext, useState } from 'react';
 import { LOGIN, LOGOUT, SECOND_AUTH, SET_NICKNAME, User, UserStateType } from '../utils/interface';
 
-export const AllContext = createContext<stateType | null>(null);
+export const AllContext = createContext<stateType>({
+  modalData: {
+    isModal: false,
+    setIsModal: () => null,
+  },
+  userData: {
+    user: null,
+    setUser: () => null,
+  },
+  userStatus: {
+    userStatus: LOGOUT,
+    setUserStatus: () => null,
+  },
+});
 
 type stateType = {
   modalData: {
-    state: boolean;
-    setState: () => void;
+    isModal: boolean;
+    setIsModal: () => void;
   };
   userData: {
-    state: User | null;
-    setState: (type: string, user?: User) => void;
+    user: User | null;
+    setUser: (type: string, user?: User) => void;
   };
-  userState: {
-    state: UserStateType;
-    setState: (type: UserStateType) => void;
+  userStatus: {
+    userStatus: UserStateType;
+    setUserStatus: (type: UserStateType) => void;
   };
 };
 
@@ -25,7 +38,7 @@ interface AllContextApiProps {
 const AllContextApi = ({ children }: AllContextApiProps) => {
   const [isModal, setIsModal] = useState<boolean>(false);
   const [user, setUser] = useState<User | null>(null);
-  const [userState, setUserState] = useState<UserStateType>(LOGOUT);
+  const [userStatus, setUserState] = useState<UserStateType>(LOGOUT);
 
   const handleModal = () => {
     setIsModal(!isModal);
@@ -53,22 +66,22 @@ const AllContextApi = ({ children }: AllContextApiProps) => {
     }
   };
 
-  const handleUserState = (type: UserStateType) => {
+  const handleUserStatus = (type: UserStateType) => {
     setUserState(type);
   };
 
   const data = {
     modalData: {
-      state: isModal,
-      setState: handleModal,
+      isModal,
+      setIsModal: handleModal,
     },
     userData: {
-      state: user,
-      setState: handleUser,
+      user,
+      setUser: handleUser,
     },
-    userState: {
-      state: userState,
-      setState: handleUserState,
+    userStatus: {
+      userStatus,
+      setUserStatus: handleUserStatus,
     },
   };
   return <AllContext.Provider value={data}>{children}</AllContext.Provider>;

--- a/frontend/src/utils/interface.ts
+++ b/frontend/src/utils/interface.ts
@@ -6,9 +6,9 @@ export interface User {
   secondAuth: boolean;
 }
 
-export const LOGIN = 'LOGIN';
-export const LOGOUT = 'LOGOUT';
-export const SET_NICKNAME = 'SET_NICKNAME';
-export const SECOND_AUTH = 'SECOND_AUTH';
+export const LOGIN = 'LOGIN' as const;
+export const LOGOUT = 'LOGOUT' as const;
+export const SET_NICKNAME = 'SET_NICKNAME' as const;
+export const SECOND_AUTH = 'SECOND_AUTH' as const;
 
 export type UserStateType = 'LOGIN' | 'LOGOUT' | 'SET_NICKNAME' | 'SECOND_AUTH';

--- a/frontend/src/utils/interface.ts
+++ b/frontend/src/utils/interface.ts
@@ -1,0 +1,14 @@
+export interface User {
+  id: number;
+  nickname: string;
+  email: string;
+  profileImg: string;
+  secondAuth: boolean;
+}
+
+export const LOGIN = 'LOGIN';
+export const LOGOUT = 'LOGOUT';
+export const SET_NICKNAME = 'SET_NICKNAME';
+export const SECOND_AUTH = 'SECOND_AUTH';
+
+export type UserStateType = 'LOGIN' | 'LOGOUT' | 'SET_NICKNAME' | 'SECOND_AUTH';


### PR DESCRIPTION
## PR 설명

- 전역적으로 관리할 변수들을 위한 Context API 를 설정하였습니다.
- 현재 Modal, User 정보, Login상태 등을 저장할 수 있도록 세팅하였습니다.
- 임시 API를 설정하여 로그인 버튼 클릭 후 42 로그인 하고 나서 callback 페이지로 이동하는데,
  이 때, 받아온 데이터에서 nickname이 설정안되어있다면 NicknamePage로,
  받아온 데이터에서 secondAuth가 true 라면 SecondAuthPage로,
  그 외의 경우에는 GamePage 로 이동하도록 세팅하였습니다.
- 상태에 따른 리디렉션도 설정했지만 개발과정을 위하여 /nickname, /secondAuth 와 같은 라우트로도 접근 가능합니다.
- Button 컴포넌트 스타일 설정 잘못된 부분 수정하였습니다.

## 관련 이슈
#7 

## 테스트 방법

- yarn dev 실행 후 가능
- 리디렉션 테스트를 위해서는 `frontend/db.json` 에서 user 영역에 nickname/secondAuth 값을 조정하면서 테스트하면 됩니다!
  - nickname: null => NicknamePage로 이동 | string => GamePage로 이동
  - secondAuth: false => GamePage로 이동 | true => SecondAuthPage로 이동

## 기타

- 이후에 필요하다고 생각되는 전역 상태는 회의 후 추가하는 방법으로 진행하면 될 듯합니다.
- 현재 테스트용으로 User 상태를 임시로 지정하였는데 수정될 수 있습니다.